### PR TITLE
feat(plugin): introduce plugin option throwOnError

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,10 @@ const Visualizer = require('webpack-visualizer-plugin2');
 
 module.exports = {
     plugins: [
-
-    new StatsWriterPlugin({
-        filename: path.join('..', 'stats', 'log.json'),
-        fields: null,
-        stats: { chunkModules: true },
-    }),
-
-    new Visualizer({
-        filename: path.join('..', 'stats', 'statistics.html'),
-    }),
-
+        new Visualizer({
+            filename: path.join('..', 'stats', 'statistics.html'),
+            throwOnError: true
+        }),
     ],
 }
 

--- a/src/plugin/plugin-app.jsx
+++ b/src/plugin/plugin-app.jsx
@@ -5,7 +5,7 @@ import Footer from '../shared/components/footer';
 import buildHierarchy from '../shared/buildHierarchy';
 import { getAssetsData, getBundleDetails, ERROR_CHUNK_MODULES } from '../shared/util/stat-utils';
 
-export default class extends React.Component {
+class App extends React.Component {
     constructor(props) {
         super(props);
 
@@ -86,3 +86,5 @@ export default class extends React.Component {
         );
     }
 }
+
+export default App;

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -6,42 +6,66 @@ let cssString = fs.readFileSync(path.join(__dirname, './style.css'), 'utf8');
 let jsString = fs.readFileSync(path.join(__dirname, './main.js'), 'utf8');
 
 module.exports = class VisualizerPlugin {
-    constructor(opts = { filename: 'stats.html' }) {
-        this.opts = opts;
+    constructor(opts = {}) {
+        this.opts = {
+            filename: 'stats.html',
+            throwOnError: true,
+            ...opts,
+        };
     }
 
     apply(compiler) {
         compiler.hooks.emit.tapAsync('Visualizer', (compilation, callback) => {
-            let stats = compilation.getStats().toJson({ chunkModules: true });
-            let stringifiedStats = JSON.stringify(stats).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            let html;
 
-            let html = `
-                <!DOCTYPE html>
-                <html lang="en">
-                    <head>
-                        <meta charset="UTF-8">
-                        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                        <title>Webpack Visualizer</title>
-                        <style>${cssString}</style>
-                    </head>
-                    <body>
-                        <div id="App"></div>
-                        <script>window.stats = ${stringifiedStats};</script>
-                        <script>${jsString}</script>
-                    </body>
-                </html>
-            `;
+            try {
+                let stats = compilation.getStats().toJson({ chunkModules: true });
+                let stringifiedStats = JSON.stringify(stats).replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+                html = `
+                    <!DOCTYPE html>
+                    <html lang="en">
+                        <head>
+                            <meta charset="UTF-8">
+                            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                            <title>Webpack Visualizer</title>
+                            <style>${cssString}</style>
+                        </head>
+                        <body>
+                            <div id="App"></div>
+                            <script>window.stats = ${stringifiedStats};</script>
+                            <script>${jsString}</script>
+                        </body>
+                    </html>
+                `;
+            } catch (error) {
+                console.error('webpack-visualizer-plugin: error creating stats file');
+                if (this.opts.throwOnError) {
+                    return callback(error);
+                } else {
+                    console.error(error);
+                    return callback();
+                }
+            }
 
             let outputFile = path.join(compilation.outputOptions.path, this.opts.filename);
 
             mkdirp(path.dirname(outputFile), (mkdirpErr) => {
                 if (mkdirpErr) {
-                    console.log('webpack-visualizer-plugin: error writing stats file');
+                    console.error('webpack-visualizer-plugin: error writing stats file');
+                    if (this.opts.throwOnError) {
+                        return callback(mkdirpErr);
+                    } else {
+                        return callback();
+                    }
                 }
 
                 fs.writeFile(outputFile, html, (err) => {
                     if (err) {
-                        console.log('webpack-visualizer-plugin: error writing stats file');
+                        console.error('webpack-visualizer-plugin: error writing stats file');
+                        if (this.opts.throwOnError) {
+                            return callback(err);
+                        }
                     }
 
                     callback();


### PR DESCRIPTION
Currently, when the plugin fail to generate html file all the `webpack` compilation fails.
This PR add ability to fail without breaking entire `webpack` compilation by adding a new option: `throwOnError` (default to true).

