### PR TITLE
feat(plugin): introduce plugin option to pass onto `compilation.getStats().toJson()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ const Visualizer = require('webpack-visualizer-plugin2');
 
 module.exports = {
     plugins: [
-        new Visualizer({
+        new Visualizer(
+        {
             filename: path.join('..', 'stats', 'statistics.html'),
             throwOnError: true,
+        },
+        {
             chunkModules: true
         }),
     ],

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ module.exports = {
     plugins: [
         new Visualizer({
             filename: path.join('..', 'stats', 'statistics.html'),
-            throwOnError: true
+            throwOnError: true,
+            chunkModules: true
         }),
     ],
 }

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -6,12 +6,15 @@ let cssString = fs.readFileSync(path.join(__dirname, './style.css'), 'utf8');
 let jsString = fs.readFileSync(path.join(__dirname, './main.js'), 'utf8');
 
 module.exports = class VisualizerPlugin {
-    constructor(opts = {}) {
+    constructor(opts = {}, statOpts = {}) {
         this.opts = {
             filename: 'stats.html',
             throwOnError: true,
-            chunkModules: true,
             ...opts,
+        };
+        this.statOpts = {
+            chunkModules: true,
+            ...statOpts,
         };
     }
 
@@ -20,7 +23,7 @@ module.exports = class VisualizerPlugin {
             let html;
 
             try {
-                let stats = compilation.getStats().toJson({ chunkModules: this.opts.chunkModules });
+                let stats = compilation.getStats().toJson(this.statOpts);
                 let stringifiedStats = JSON.stringify(stats).replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
                 html = `

--- a/src/plugin/plugin.js
+++ b/src/plugin/plugin.js
@@ -10,6 +10,7 @@ module.exports = class VisualizerPlugin {
         this.opts = {
             filename: 'stats.html',
             throwOnError: true,
+            chunkModules: true,
             ...opts,
         };
     }
@@ -19,7 +20,7 @@ module.exports = class VisualizerPlugin {
             let html;
 
             try {
-                let stats = compilation.getStats().toJson({ chunkModules: true });
+                let stats = compilation.getStats().toJson({ chunkModules: this.opts.chunkModules });
                 let stringifiedStats = JSON.stringify(stats).replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
                 html = `


### PR DESCRIPTION
The hard-coded `chunkModules` in particular and `statOptions` in general can be  configurable up to user choices.
It could help many developers fixing their own issues too